### PR TITLE
Updated 160x128 example to use correct init sequence and fixed esp8266

### DIFF
--- a/Adafruit_ImageReader.cpp
+++ b/Adafruit_ImageReader.cpp
@@ -477,7 +477,7 @@ ImageReturnCode Adafruit_ImageReader::bmpDimensions(
     @return  Unsigned 16-bit value, native endianism.
 */
 uint16_t Adafruit_ImageReader::readLE16(void) {
-#if !defined(ESP32) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#if !defined(ESP32) && !defined(ESP8266) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   // Read directly into result -- BMP data and variable both little-endian.
   uint16_t result;
   file.read(&result, sizeof result);
@@ -495,7 +495,7 @@ uint16_t Adafruit_ImageReader::readLE16(void) {
     @return  Unsigned 32-bit value, native endianism.
 */
 uint32_t Adafruit_ImageReader::readLE32(void) {
-#if !defined(ESP32) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#if !defined(ESP32) && !defined(ESP8266) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   // Read directly into result -- BMP data and variable both little-endian.
   uint32_t result;
   file.read(&result, sizeof result);

--- a/examples/BreakoutST7735-160x128/BreakoutST7735-160x128.ino
+++ b/examples/BreakoutST7735-160x128/BreakoutST7735-160x128.ino
@@ -36,7 +36,7 @@ void setup(void) {
   while(!Serial);       // Wait for Serial Monitor before continuing
 #endif
 
-  tft.initR(INITR_GREENTAB); // Initialize screen
+  tft.initR(INITR_BLACKTAB); // Initialize screen
 
   Serial.print(F("Initializing SD card..."));
   if(!SD.begin(SD_CS)) {


### PR DESCRIPTION
The 160x128 1.8" Display example was using the init sequence for the 128x128 1.44" display. I updated it to use the correct one.