### PR TITLE
Fixes for TFT Gizmo example for CPX

### DIFF
--- a/examples/TFTGizmo/TFTGizmo.ino
+++ b/examples/TFTGizmo/TFTGizmo.ino
@@ -25,7 +25,7 @@
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS,
     PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/TFTGizmo/TFTGizmo.ino
+++ b/examples/TFTGizmo/TFTGizmo.ino
@@ -31,11 +31,19 @@
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
   #endif
 #endif
+
+// TFT SPI interface selection
+#if (SPI_INTERFACES_COUNT == 1)
+  SPIClass* spi = &SPI;
+#else
+  SPIClass* spi = &SPI1;
+#endif
+
 Adafruit_SPIFlash    flash(&flashTransport);
 FatFileSystem        filesys;
 Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 
-Adafruit_ST7789      tft    = Adafruit_ST7789(TFT_CS, TFT_DC, TFT_RST);
+Adafruit_ST7789      tft    = Adafruit_ST7789(spi, TFT_CS, TFT_DC, TFT_RST);
 Adafruit_Image       img;        // An image loaded into RAM
 int32_t              width  = 0, // BMP image dimensions
                      height = 0;


### PR DESCRIPTION
Same issue with SPIFlash and forgot to add TFT SPI selection the first time.