### PR TITLE
Updated SD_CS pin in E-Ink breakout example to match guide

### DIFF
--- a/examples/EInkBreakouts/EInkBreakouts.ino
+++ b/examples/EInkBreakouts/EInkBreakouts.ino
@@ -18,7 +18,7 @@
 #define SRAM_CS     8
 #define EPD_RESET   5 // can set to -1 and share with microcontroller Reset!
 #define EPD_BUSY    3 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SD_CS       7 // SD card select pin
+#define SD_CS       4 // SD card chip select
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
 Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit ImageReader Library
-version=2.3.0
+version=2.3.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Companion library for Adafruit_GFX and Adafruit_EPD to load images from SD card.


### PR DESCRIPTION
I noticed it should have been 4 when I went to update the guide. The example I originally referenced just happened to use 7.