### PR TITLE
Fix esp8266 build

### DIFF
--- a/Adafruit_ImageReader.cpp
+++ b/Adafruit_ImageReader.cpp
@@ -214,7 +214,7 @@ void Adafruit_Image::draw(Adafruit_SPITFT &tft, int16_t x, int16_t y) {
              often be in pre-setup() declaration, but DOES need initializing
              before any of the image loading or size functions are called!
 */
-Adafruit_ImageReader::Adafruit_ImageReader(FatFileSystem &fs) { filesys = &fs; }
+Adafruit_ImageReader::Adafruit_ImageReader(FatVolume &fs) { filesys = &fs; }
 
 /*!
     @brief   Destructor.

--- a/Adafruit_ImageReader.h
+++ b/Adafruit_ImageReader.h
@@ -94,7 +94,7 @@ protected:
 */
 class Adafruit_ImageReader {
 public:
-  Adafruit_ImageReader(FatFileSystem &fs);
+  Adafruit_ImageReader(FatVolume &fs);
   ~Adafruit_ImageReader(void);
   ImageReturnCode drawBMP(const char *filename, Adafruit_SPITFT &tft, int16_t x,
                           int16_t y, boolean transact = true);
@@ -104,7 +104,7 @@ public:
 
 protected:
   FatVolume *filesys; ///< FAT FileSystem Object
-  File32 file;              ///< Current Open file
+  File32 file;        ///< Current Open file
   ImageReturnCode coreBMP(const char *filename, Adafruit_SPITFT *tft,
                           uint16_t *dest, int16_t x, int16_t y,
                           Adafruit_Image *img, boolean transact);

--- a/Adafruit_ImageReader.h
+++ b/Adafruit_ImageReader.h
@@ -103,8 +103,8 @@ public:
   void printStatus(ImageReturnCode stat, Stream &stream = Serial);
 
 protected:
-  FatFileSystem *filesys; ///< FAT FileSystem Object
-  File file;              ///< Current Open file
+  FatVolume *filesys; ///< FAT FileSystem Object
+  File32 file;              ///< Current Open file
   ImageReturnCode coreBMP(const char *filename, Adafruit_SPITFT *tft,
                           uint16_t *dest, int16_t x, int16_t y,
                           Adafruit_Image *img, boolean transact);

--- a/Adafruit_ImageReader_EPD.cpp
+++ b/Adafruit_ImageReader_EPD.cpp
@@ -88,7 +88,7 @@ void Adafruit_Image_EPD::draw(Adafruit_EPD &epd, int16_t x, int16_t y) {
              often be in pre-setup() declaration, but DOES need initializing
              before any of the image loading or size functions are called!
 */
-Adafruit_ImageReader_EPD::Adafruit_ImageReader_EPD(FatFileSystem &fs)
+Adafruit_ImageReader_EPD::Adafruit_ImageReader_EPD(FatVolume &fs)
     : Adafruit_ImageReader(fs) {}
 
 /*!

--- a/Adafruit_ImageReader_EPD.h
+++ b/Adafruit_ImageReader_EPD.h
@@ -44,7 +44,7 @@ protected:
 */
 class Adafruit_ImageReader_EPD : public Adafruit_ImageReader {
 public:
-  Adafruit_ImageReader_EPD(FatFileSystem &fs);
+  Adafruit_ImageReader_EPD(FatVolume &fs);
   ImageReturnCode drawBMP(char *filename, Adafruit_EPD &epd, int16_t x,
                           int16_t y, boolean transact = true);
 

--- a/examples/BreakoutSSD1331/BreakoutSSD1331.ino
+++ b/examples/BreakoutSSD1331/BreakoutSSD1331.ino
@@ -50,7 +50,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -72,7 +72,7 @@ void setup(void) {
   tft.begin(); // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/BreakoutSSD1351/BreakoutSSD1351.ino
+++ b/examples/BreakoutSSD1351/BreakoutSSD1351.ino
@@ -54,7 +54,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -76,7 +76,7 @@ void setup(void) {
   tft.begin(); // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/BreakoutST7735-128x128/BreakoutST7735-128x128.ino
+++ b/examples/BreakoutST7735-128x128/BreakoutST7735-128x128.ino
@@ -40,7 +40,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -61,7 +61,7 @@ void setup(void) {
   tft.initR(INITR_144GREENTAB); // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/BreakoutST7735-160x128/BreakoutST7735-160x128.ino
+++ b/examples/BreakoutST7735-160x128/BreakoutST7735-160x128.ino
@@ -40,7 +40,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -61,7 +61,7 @@ void setup(void) {
   tft.initR(INITR_BLACKTAB); // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/BreakoutST7735-160x80/BreakoutST7735-160x80.ino
+++ b/examples/BreakoutST7735-160x80/BreakoutST7735-160x80.ino
@@ -41,7 +41,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -63,7 +63,7 @@ void setup(void) {
   Serial.println(F("TFT initialized."));
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/BreakoutST7789-320x240/BreakoutST7789-320x240.ino
+++ b/examples/BreakoutST7789-320x240/BreakoutST7789-320x240.ino
@@ -40,7 +40,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -61,7 +61,7 @@ void setup(void) {
   tft.init(240, 320);           // Init ST7789 320x240
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/EInkBreakouts/EInkBreakouts.ino
+++ b/examples/EInkBreakouts/EInkBreakouts.ino
@@ -60,7 +60,7 @@ Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
     #endif
   #endif
   Adafruit_SPIFlash         flash(&flashTransport);
-  FatFileSystem             filesys;
+  FatVolume             filesys;
   Adafruit_ImageReader_EPD  reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -84,7 +84,7 @@ void setup(void) {
 #endif
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
   // SPI or QSPI flash requires two steps, one to access the bare flash

--- a/examples/EInkFeatherWing/EInkFeatherWing.ino
+++ b/examples/EInkFeatherWing/EInkFeatherWing.ino
@@ -76,7 +76,7 @@ Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
     #endif
   #endif
   Adafruit_SPIFlash         flash(&flashTransport);
-  FatFileSystem             filesys;
+  FatVolume             filesys;
   Adafruit_ImageReader_EPD  reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -100,7 +100,7 @@ void setup(void) {
 #endif
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
   // SPI or QSPI flash requires two steps, one to access the bare flash

--- a/examples/EInkGizmo/EInkGizmo.ino
+++ b/examples/EInkGizmo/EInkGizmo.ino
@@ -32,7 +32,7 @@ ThinkInk_154_Tricolor_Z90 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 #endif
 
 Adafruit_SPIFlash         flash(&flashTransport);
-FatFileSystem             filesys;
+FatVolume             filesys;
 Adafruit_ImageReader_EPD  reader(filesys); // Image-reader, pass in flash filesys
 
 Adafruit_Image_EPD   img;        // An image loaded into RAM
@@ -49,7 +49,7 @@ void setup(void) {
   display.setRotation(3);  
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
   // SPI or QSPI flash requires two steps, one to access the bare flash

--- a/examples/FeatherWingHX8357/FeatherWingHX8357.ino
+++ b/examples/FeatherWingHX8357/FeatherWingHX8357.ino
@@ -62,7 +62,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -83,7 +83,7 @@ void setup(void) {
   tft.begin();          // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/FeatherWingILI9341/FeatherWingILI9341.ino
+++ b/examples/FeatherWingILI9341/FeatherWingILI9341.ino
@@ -62,7 +62,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -81,7 +81,7 @@ void setup(void) {
   tft.begin();          // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/FeatherWingST7735/FeatherWingST7735.ino
+++ b/examples/FeatherWingST7735/FeatherWingST7735.ino
@@ -41,7 +41,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -71,7 +71,7 @@ void setup(void) {
   Serial.println(F("TFT initialized."));
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/PyPortal/PyPortal.ino
+++ b/examples/PyPortal/PyPortal.ino
@@ -38,7 +38,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 Adafruit_ILI9341       tft(tft8bitbus, TFT_D0, TFT_WR, TFT_DC, TFT_CS, TFT_RST, TFT_RD);
@@ -60,7 +60,7 @@ void setup(void) {
   tft.begin();          // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/ShieldILI9341/ShieldILI9341.ino
+++ b/examples/ShieldILI9341/ShieldILI9341.ino
@@ -39,7 +39,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -60,7 +60,7 @@ void setup(void) {
   tft.begin();          // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/ShieldST7735/ShieldST7735.ino
+++ b/examples/ShieldST7735/ShieldST7735.ino
@@ -43,7 +43,7 @@
     #endif
   #endif
   Adafruit_SPIFlash    flash(&flashTransport);
-  FatFileSystem        filesys;
+  FatVolume        filesys;
   Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -73,7 +73,7 @@ void setup(void) {
   tft.initR(INITR_BLACKTAB); // Initialize screen
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)

--- a/examples/TFTGizmo/TFTGizmo.ino
+++ b/examples/TFTGizmo/TFTGizmo.ino
@@ -37,7 +37,7 @@
 #endif
 
 Adafruit_SPIFlash    flash(&flashTransport);
-FatFileSystem        filesys;
+FatVolume        filesys;
 Adafruit_ImageReader reader(filesys); // Image-reader, pass in flash filesys
 
 Adafruit_ST7789      tft    = Adafruit_ST7789(spi, TFT_CS, TFT_DC, TFT_RST);
@@ -58,7 +58,7 @@ void setup(void) {
   digitalWrite(TFT_BACKLIGHT, HIGH); // Backlight on
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
   // SPI or QSPI flash requires two steps, one to access the bare flash

--- a/examples/ThinkInkDisplays/ThinkInkDisplays.ino
+++ b/examples/ThinkInkDisplays/ThinkInkDisplays.ino
@@ -61,7 +61,7 @@ ThinkInk_290_Tricolor_Z10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
     #endif
   #endif
   Adafruit_SPIFlash         flash(&flashTransport);
-  FatFileSystem             filesys;
+  FatVolume             filesys;
   Adafruit_ImageReader_EPD  reader(filesys); // Image-reader, pass in flash filesys
 #endif
 
@@ -85,7 +85,7 @@ void setup(void) {
 #endif
 
   // The Adafruit_ImageReader constructor call (above, before setup())
-  // accepts an uninitialized SdFat or FatFileSystem object. This MUST
+  // accepts an uninitialized SdFat or FatVolume object. This MUST
   // BE INITIALIZED before using any of the image reader functions!
   Serial.print(F("Initializing filesystem..."));
   // SPI or QSPI flash requires two steps, one to access the bare flash


### PR DESCRIPTION
update SdFat v2 compatible
- use File32 to replace File
- use FatVolume to replace FatFileSystem : this is not really needed since FatFileSystem is defined to FatVolume. Though I take the chance to update it anyway.