### PR TITLE
SPI clock comment for M0

### DIFF
--- a/examples/FeatherWingHX8357/FeatherWingHX8357.ino
+++ b/examples/FeatherWingHX8357/FeatherWingHX8357.ino
@@ -88,6 +88,7 @@ void setup(void) {
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)
   // SD card is pretty straightforward, a single call...
+  // Use 12 MHz or less for Feather M0 based boards
   if(!SD.begin(SD_CS, SD_SCK_MHZ(25))) { // ESP32 requires 25 MHz limit
     Serial.println(F("SD begin() failed"));
     for(;;); // Fatal error, do not continue

--- a/examples/FeatherWingILI9341/FeatherWingILI9341.ino
+++ b/examples/FeatherWingILI9341/FeatherWingILI9341.ino
@@ -86,6 +86,7 @@ void setup(void) {
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)
   // SD card is pretty straightforward, a single call...
+  // Use 12 MHz or less for Feather M0 based boards
   if(!SD.begin(SD_CS, SD_SCK_MHZ(25))) { // ESP32 requires 25 MHz limit
     Serial.println(F("SD begin() failed"));
     for(;;); // Fatal error, do not continue

--- a/examples/FeatherWingST7735/FeatherWingST7735.ino
+++ b/examples/FeatherWingST7735/FeatherWingST7735.ino
@@ -76,6 +76,7 @@ void setup(void) {
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)
   // SD card is pretty straightforward, a single call...
+  // Use 12 MHz or less for Feather M0 based boards
   if(!SD.begin(SD_CS, SD_SCK_MHZ(25))) { // ESP32 requires 25 MHz limit
     Serial.println(F("SD begin() failed"));
     for(;;); // Fatal error, do not continue


### PR DESCRIPTION
This is only a comment addition to help troubleshooting. Modern chips are fine with 25 MHz SPI clock, but the older M0 needs 12 MHz or less with the FeatherWings TFTs microSD cards.

```
+---------------------+--------+--------+--------+
| Chip                | 25 MHz | 12 MHz | 8 MHz  |
+---------------------+--------+--------+--------+
| Feather M0 WINC1500 |    x   |    o   |    o   |
| Feather ESP32 V2    |    o   |    o   |    o   |
| Feather M0 Express  |    x   |    o   |    o   |
+---------------------+--------+--------+--------+
```

Changing the default example clock from 25 --> 12 helped [resolve a forum issue](https://forums.adafruit.com/viewtopic.php?t=215642) with the Feather M0 <--> FeatherWing 3.5" HX8357.

Most of the breakouts use 10 MHz for wire length accomidation.

```
+-----------------------------------+---------------------+
|            Directory              | SPI Frequency (MHz) |
+-----------------------------------+---------------------+
| FeatherWingST7735                 | 25                  |
| FeatherWingILI9341                | 25                  |
| FeatherWingHX8357                 | 25                  |
| ShieldST7735                       | 25                  |
| ShieldILI9341                      | 25                  |
| PyPortal                          | 25                  |
| BreakoutST7735-160x80             | 10                  |
| BreakoutST7789-170x320            | 10                  |
| BreakoutST7735-128x128            | 10                  |
| BreakoutST7789-172x320            | 10                  |
| ThinkInkDisplays                  | 10                  |
| BreakoutSSD1351                   | 10                  |
| EInkFeatherWing                   | 10                  |
| BreakoutST7735-160x128            | 10                  |
| BreakoutST7789-240x135            | 10                  |
| EInkGray29BmpButtonDemo           | 10                  |
| BreakoutST7789-240x240            | 10                  |
| BreakoutST7789-320x240            | 10                  |
| BreakoutST7789-280x240            | 10                  |
| BreakoutSSD1331                   | 10                  |
| EInkBreakouts                     | 10                  |
+-----------------------------------+---------------------+
```