### PR TITLE
Featherwings reduce SPI  on microSD to 12 MHz

### DIFF
--- a/examples/FeatherWingHX8357/FeatherWingHX8357.ino
+++ b/examples/FeatherWingHX8357/FeatherWingHX8357.ino
@@ -88,7 +88,9 @@ void setup(void) {
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)
   // SD card is pretty straightforward, a single call...
-  if(!SD.begin(SD_CS, SD_SCK_MHZ(25))) { // ESP32 requires 25 MHz limit
+  // M0 max SPI is 12 MHz
+  // ESP32 can handl 25 MHz
+  if(!SD.begin(SD_CS, SD_SCK_MHZ(12))) {
     Serial.println(F("SD begin() failed"));
     for(;;); // Fatal error, do not continue
   }

--- a/examples/FeatherWingILI9341/FeatherWingILI9341.ino
+++ b/examples/FeatherWingILI9341/FeatherWingILI9341.ino
@@ -86,7 +86,9 @@ void setup(void) {
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)
   // SD card is pretty straightforward, a single call...
-  if(!SD.begin(SD_CS, SD_SCK_MHZ(25))) { // ESP32 requires 25 MHz limit
+  // M0 max SPI is 12 MHz
+  // ESP32 can handl 25 MHz
+  if(!SD.begin(SD_CS, SD_SCK_MHZ(12))) {
     Serial.println(F("SD begin() failed"));
     for(;;); // Fatal error, do not continue
   }

--- a/examples/FeatherWingST7735/FeatherWingST7735.ino
+++ b/examples/FeatherWingST7735/FeatherWingST7735.ino
@@ -76,7 +76,9 @@ void setup(void) {
   Serial.print(F("Initializing filesystem..."));
 #if defined(USE_SD_CARD)
   // SD card is pretty straightforward, a single call...
-  if(!SD.begin(SD_CS, SD_SCK_MHZ(25))) { // ESP32 requires 25 MHz limit
+  // M0 max SPI is 12 MHz
+  // ESP32 can handl 25 MHz
+  if(!SD.begin(SD_CS, SD_SCK_MHZ(12))) {
     Serial.println(F("SD begin() failed"));
     for(;;); // Fatal error, do not continue
   }


### PR DESCRIPTION
The Feather M0 stops displaying images if the microSD SPI bus is over 12 MHz. This change it to lower the current FeatherWing display examples from 25 MHz --> 12 MHz to support more boards.

Tested on Arduino 2.3.6 / macOS 15.5 

3.5" FeatherWing ADA# [3651](https://www.adafruit.com/product/3651)

```
Board                     | 8 MHz | 12 MHz | 25 MHz
--------------------------|-------|--------|-------
Adafruit Feather ESP32 V2 |   ✓   |   ✓    |   ✓
Adafruit Feather M0 Proto |   ✓   |   ✓    |   x
```