### PR TITLE
adding ifdef for feather rp2040

### DIFF
--- a/examples/FeatherWingHX8357/FeatherWingHX8357.ino
+++ b/examples/FeatherWingHX8357/FeatherWingHX8357.ino
@@ -40,6 +40,10 @@
   #define TFT_CS   P5_3
   #define STMPE_CS P3_3
   #define SD_CS    P3_2
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+  #define TFT_CS   9
+  #define TFT_DC   10
+  #define SD_CS    7 // "pin 5" on original rp2040 feather ONLY
 #else // Anything else!
   #define TFT_CS   9
   #define TFT_DC   10

--- a/examples/FeatherWingILI9341/FeatherWingILI9341.ino
+++ b/examples/FeatherWingILI9341/FeatherWingILI9341.ino
@@ -40,6 +40,10 @@
   #define TFT_CS   P5_3
   #define STMPE_CS P3_3
   #define SD_CS    P3_2
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+  #define TFT_CS   9
+  #define TFT_DC   10
+  #define SD_CS    7 // "pin 5" on original rp2040 feather ONLY
 #else // Anything else!
   #define TFT_CS   9
   #define TFT_DC   10


### PR DESCRIPTION
adding ifdef for feather rp2040 for featherwing display examples. the original feather rp2040's "pin 5" is actually pin 7 in arduino (labeled on back of board silk)

this came up in https://github.com/adafruit/Adafruit_ImageReader/issues/62