### PR TITLE
Correct filename in comment.

### DIFF
--- a/examples/BreakoutST7789-240x240/BreakoutST7789-240x240.ino
+++ b/examples/BreakoutST7789-240x240/BreakoutST7789-240x240.ino
@@ -2,7 +2,7 @@
 // Demonstrates loading images to the screen, to RAM, and how to query
 // image file dimensions.
 // Requires three BMP files in root directory of SD card:
-// parrot.bmp, miniwoof.bmp and wales.bmp.
+// adabot.bmp, miniwoof.bmp and wales.bmp.
 // As written, this uses the microcontroller's SPI interface for the screen
 // (not 'bitbang') and must be wired to specific pins (e.g. for Arduino Uno,
 // MOSI = pin 11, MISO = 12, SCK = 13). Other pins are configurable below.


### PR DESCRIPTION
This is a no-op, comment edit only. One of the filenames in the comments does not match the actual filename used. 